### PR TITLE
chore: trying to let TS 6 be a valid peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vitest": "^2.1.5"
   },
   "peerDependencies": {
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3 || ^6.0.0"
   },
   "keywords": [
     "bm25",


### PR DESCRIPTION
Thank you for the library. Very cool.

I have a project that I want to update to TypeScript 6. If I do so, I get a 'unmet peer dependency' warning, stating that `fast-bm25` wants specifically `^5.6.3`.

```sh
Issues with peer dependencies found

✕ unmet peer typescript
  Installed: 6.0.3
  Wanted:
    ^5.6.3:
      fast-bm25@0.0.5
```

 Can we add `^6.0.0` to the specifier? Not sure if this would break anything.

Thanks again.